### PR TITLE
Unbuffered query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0 / 2019-07-02
+
+* Added enumerator-based result access methods: `#rows` and `#records`
+* Fixed bug dropping headers from memoized rows across `#to_h` and `#to_a(header_row: true)`
+
 ## 0.2.0 / 2019-03-20
 
 * Added support for NULL values.  Columns with a nullable status of "NULLABLE" or "UNKNOWN" will return nil for NULL values

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    athens (0.2.0)
+    athens (0.3.0)
       aws-sdk-athena (~> 1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ results = query.to_h
 # ]
 ```
 
+Results are also available as unbuffered enumerators of row arrays:
+```ruby
+query.rows.each {|row| ...}
+# ['column_1', 'column_2', 'column_3']
+# [15, 'data', true]
+# [20, 'foo', false],
+# ...
+```
+
+Or hashes:
+```ruby
+query.records.each {|record| ...}
+# {'column_1': 15, 'column_2': 'data', 'column_3': true}
+# {'column_1': 20, 'column_2': 'foo', 'column_3': false}
+# ...
+```
+
 Athens attempts to parse the sql data types into their ruby equivalents, although there's currently no support for the more complex Array/Map types.
 
 ### Configuration

--- a/lib/athens/query.rb
+++ b/lib/athens/query.rb
@@ -99,30 +99,27 @@ module Athens
       end
     end
 
+    def records
+      Enumerator.new do |y|
+        headers = nil
+
+        rows.each_with_index do |row|
+          if headers.nil?
+            headers = row
+            next
+          end
+
+          y << Hash[headers.zip(row)]
+        end
+      end
+    end
+
     def to_a(header_row: true)
       (@results ||= rows.to_a).drop(header_row ? 0 : 1)
     end
 
     def to_h
-      if @hash_results.nil?
-        all_rows = self.to_a(header_row: true)
-
-        headers = all_rows.shift
-
-        @hash_results = []
-
-        unless headers.nil?
-          all_rows.each do |row|
-            map = {}
-            headers.each_with_index do |header, index|
-              map[header] = row[index]
-            end
-            @hash_results << map
-          end
-        end
-      end
-
-      return @hash_results
+      @hash_results ||= records.to_a
     end
 
     private

--- a/lib/athens/version.rb
+++ b/lib/athens/version.rb
@@ -1,3 +1,3 @@
 module Athens
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
This PR extends the query interface to offer unbuffered results. Two methods are introduced:

- `#rows` returns an `Enumerator` of row arrays, with the header always included; and
- `#records` returns an `Enumerator` of record hashes.

`#to_a` and `#to_h` have been reimplemented using these. A subtle bug has also been fixed where the [modified memoized result state][1] would bleed across calls of `#to_h` and `#to_a(header_row: true)`.

[1]: https://github.com/getletterpress/athens/blob/master/lib/athens/query.rb#L119