### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,30 @@
 PATH
   remote: .
   specs:
-    athens (0.3.1)
+    athens (0.3.2)
       aws-sdk-athena (~> 1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.343.0)
-    aws-sdk-athena (1.30.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-partitions (1.416.0)
+    aws-sdk-athena (1.33.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.104.1)
+    aws-sdk-core (3.111.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sigv4 (1.2.1)
+    aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
     jmespath (1.4.0)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    racc (1.5.2)
     rake (13.0.1)
 
 PLATFORMS
@@ -27,8 +32,9 @@ PLATFORMS
 
 DEPENDENCIES
   athens!
-  bundler (~> 1.17)
+  bundler (>= 1.17)
+  nokogiri (~> 1)
   rake (~> 13.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.5

--- a/athens.gemspec
+++ b/athens.gemspec
@@ -32,10 +32,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency "aws-sdk-athena", "~> 1"
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "nokogiri", "~> 1"
 end


### PR DESCRIPTION
Changed .gemspec to allow ruby-3.0 and latest bundler.

Also included Nokogiri to development_dependency to solve following error.

```ruby
❯ ./bin/console
/Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core/xml/parser.rb:74:in `set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core/xml/parser.rb:96:in `<class:Parser>'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core/xml/parser.rb:7:in `<module:Xml>'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core/xml/parser.rb:5:in `<module:Aws>'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core/xml/parser.rb:3:in `<top (required)>'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core/xml.rb:8:in `require_relative'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core/xml.rb:8:in `<top (required)>'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core.rb:68:in `require_relative'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.111.0/lib/aws-sdk-core.rb:68:in `<top (required)>'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-athena-1.33.0/lib/aws-sdk-athena.rb:11:in `require'
        from /Users/hirokigoto/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-athena-1.33.0/lib/aws-sdk-athena.rb:11:in `<top (required)>'
        from /Users/hirokigoto/workplace/athens/lib/athens.rb:7:in `require'
        from /Users/hirokigoto/workplace/athens/lib/athens.rb:7:in `<top (required)>'
        from ./bin/console:4:in `require'
        from ./bin/console:4:in `<main>'

``` 