### PR TITLE
Adds :aws_profile as a way to provide credentials 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    athens (0.3.3)
+    athens (0.3.4)
       aws-sdk-athena (~> 1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.416.0)
+    aws-partitions (1.420.0)
     aws-sdk-athena (1.33.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.111.0)
+    aws-sdk-core (3.111.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)

--- a/lib/athens/configuration.rb
+++ b/lib/athens/configuration.rb
@@ -1,15 +1,17 @@
 module Athens
   class Configuration
-    attr_accessor :aws_access_key, 
+    attr_accessor :aws_access_key,
                   :aws_secret_key,
                   :aws_region,
-                  :output_location
+                  :output_location,
+                  :aws_profile
 
     def initialize
       @aws_access_key = nil
       @aws_secret_key = nil
       @aws_region = nil
       @output_location = nil
+      @aws_profile = nil
     end
   end
 end

--- a/lib/athens/connection.rb
+++ b/lib/athens/connection.rb
@@ -8,11 +8,18 @@ module Athens
     def initialize(database: nil, aws_client_override: {})
       @database_name = database
 
-      client_config = {
-        access_key_id: Athens.configuration.aws_access_key,
-        secret_access_key: Athens.configuration.aws_secret_key,
-        region: Athens.configuration.aws_region
-      }.merge(aws_client_override).compact
+      if (Athens.configuration.aws_profile)
+        puts("Using the aws_profile approach")
+        client_config = {
+          profile: Athens.configuration.aws_profile
+        }.merge(aws_client_override).compact
+      else
+        client_config = {
+          access_key_id: Athens.configuration.aws_access_key,
+          secret_access_key: Athens.configuration.aws_secret_key,
+          region: Athens.configuration.aws_region
+        }.merge(aws_client_override).compact
+      end
 
       @client = Aws::Athena::Client.new(client_config)
     end

--- a/lib/athens/connection.rb
+++ b/lib/athens/connection.rb
@@ -9,7 +9,6 @@ module Athens
       @database_name = database
 
       if (Athens.configuration.aws_profile)
-        puts("Using the aws_profile approach")
         client_config = {
           profile: Athens.configuration.aws_profile
         }.merge(aws_client_override).compact

--- a/lib/athens/version.rb
+++ b/lib/athens/version.rb
@@ -1,3 +1,3 @@
 module Athens
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end


### PR DESCRIPTION
For multiple AWS accounts and different cross-account roles, users will usually have a `~/.aws/credentials` file with multiple profiles. This PR contains some extra code to allow use of a named `aws_profile` in the `Athens.configure` block.

```ruby
    Athens.configure do |config|
      config.output_location = "s3://bucket/folder"  # Required
      config.aws_profile = "development"
    end
```
