### PR TITLE
Use BigDecimal without new in Ruby 3.x

### DIFF
--- a/lib/athens/query.rb
+++ b/lib/athens/query.rb
@@ -14,6 +14,7 @@ module Athens
 
       version = RUBY_VERSION.split('.').map {|v| v.to_i}
       @decimal_without_new = (version[0] >= 2 && version[1] >= 5)
+      @decimal_without_new = (version[0] == 2 && version[1] >= 5) || (version[0] >= 3)
     end
 
     def state


### PR DESCRIPTION
Thanks for this wrapper, it makes the interface look much more manageable than the generated AWS gem. 😃 

While the latest version seems to be compatible with Ruby 3.x the BigDecimal handling is not yet.