### PR TITLE
Result encryption options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 /.vagrant/
 /ubuntu-xenial-16.04-cloudimg-console.log
+/vendor/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,20 +7,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.1.1)
-    aws-partitions (1.458.0)
-    aws-sdk-athena (1.37.0)
-      aws-sdk-core (~> 3, >= 3.112.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.530.0)
+    aws-sdk-athena (1.43.0)
+      aws-sdk-core (~> 3, >= 3.122.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.114.0)
+    aws-sdk-core (3.122.1)
       aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.239.0)
+      aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sigv4 (1.2.3)
+    aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
     jmespath (1.4.0)
-    rake (13.0.3)
+    rake (13.0.6)
     rexml (3.2.5)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Athens.configure do |config|
   config.aws_profile         = 'myprofile'  # Optional
   config.aws_region          = 'us-east-1'  # Optional
   config.wait_polling_period = 0.25         # Optional - What period should we poll for the complete query?
+  config.result_encryption   = nil          # Optional, see below
 end
 ```
 
@@ -104,6 +105,14 @@ conn = Athens::Connection.new(aws_client_override: {})
 ```
 
 Take a look at the [AWS Athena SDK](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Athena/Client.html#initialize-instance_method) for a list of all the available options.
+
+The `result_encryption` option controls how the Athens results will be encrypted at the `output_location`.  By default it's set to use the Amazon SSE encryption if you don't set it at all:
+
+```ruby
+{ encryption_option: "SSE_S3" }
+```
+
+If you set it to `nil`, it'll default to the bucket encryption settings.  You can also use a customer kms key, see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Athena/Types/EncryptionConfiguration.html for the correct format.
 
 ### Advanced Usage
 

--- a/lib/athens/configuration.rb
+++ b/lib/athens/configuration.rb
@@ -5,7 +5,8 @@ module Athens
                   :aws_region,
                   :output_location,
                   :wait_polling_period,
-                  :aws_profile
+                  :aws_profile,
+                  :result_encryption
 
     def initialize
       @aws_access_key = nil
@@ -14,6 +15,7 @@ module Athens
       @output_location = nil
       @wait_polling_period = 0.25
       @aws_profile = nil
+      @result_encryption = { encryption_option: "SSE_S3" }
     end
   end
 end

--- a/lib/athens/connection.rb
+++ b/lib/athens/connection.rb
@@ -48,9 +48,7 @@ module Athens
       def result_config
         Aws::Athena::Types::ResultConfiguration.new(
           output_location: Athens.configuration.output_location,
-          encryption_configuration: {
-            encryption_option: "SSE_S3"
-          }
+          encryption_configuration: Athens.configuration.result_encryption
         )
       end
 


### PR DESCRIPTION
Added a `result_encryption` configuration option to change the way athens output is encrypted (or not encrypted).  Closes #12 