### PR TITLE
Unpin aws core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2 / 2024-03-04
+
+* Not locking `aws-sdk-core` gem version because `aws-sdk-athena` already requires it
+
 ## 0.4.1 / 2022-06-16
 
 * Specifying minimum version of `aws-sdk-core` gem for `jmespath` security issue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,29 @@
 PATH
   remote: .
   specs:
-    athens (0.4.0)
+    athens (0.4.2)
       aws-sdk-athena (~> 1)
-      aws-sdk-core (~> 3.131.1)
       multi_json (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.2.0)
-    aws-partitions (1.599.0)
-    aws-sdk-athena (1.53.0)
-      aws-sdk-core (~> 3, >= 3.127.0)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.895.0)
+    aws-sdk-athena (1.81.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.131.1)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.525.0)
-      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.191.3)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sigv4 (1.5.0)
+    aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    jmespath (1.6.1)
+    jmespath (1.6.2)
     multi_json (1.15.0)
-    rake (13.0.6)
-    rexml (3.2.5)
+    rake (13.1.0)
+    rexml (3.2.6)
 
 PLATFORMS
   ruby

--- a/athens.gemspec
+++ b/athens.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_dependency "aws-sdk-core", "~> 3.131.1"
   spec.add_dependency "aws-sdk-athena", "~> 1"
   spec.add_dependency 'multi_json', '~> 1.0'
 

--- a/lib/athens/version.rb
+++ b/lib/athens/version.rb
@@ -1,3 +1,3 @@
 module Athens
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
No need to pin the `aws-sdk-core` gem because `aws-sdk-athena` requires it.  Bumping version to 0.4.2.

Closes #18 